### PR TITLE
Dark mode

### DIFF
--- a/htmldiff.js
+++ b/htmldiff.js
@@ -435,6 +435,7 @@ function generateBottomBit() {
     "    monstrous diffs.\n" +
     "  </footer>\n" +
     "  <script src=\"//code.jquery.com/jquery-1.12.0.min.js\"></script>\n" +
+    "  <script src=\"/assets/js/jquery.cookie.js\"></script>\n" +
     "  <script src=\"/assets/js/diff.js\"></script>\n" +
     "</body>\n" +
     "</html>";

--- a/public/assets/css/diff-dark.css
+++ b/public/assets/css/diff-dark.css
@@ -1,4 +1,70 @@
 body {
-  background: #999;
+  background: #1A1A1A;
+  color: #EEE;
 }
 
+a {
+  color: #0AF;
+}
+
+a:visited {
+  color: #C2F;
+}
+
+tr {
+  background: #111;
+}
+
+.addition {
+  background-color: #002A00;
+}
+
+.removal {
+  background-color: #500;
+}
+
+.position {
+  background-color: #112;
+  color: #AAA;
+}
+
+tr.highlighted {
+  background-color: #055;
+}
+
+.file-wrapper {
+  border-color: #555;
+}
+
+.file-wrapper header {
+  background: #282828;
+}
+
+td.lineno {
+  border-right-color: rgba(255, 255, 255, .1);
+  color: #999;
+}
+
+td.lineno a {
+  color: #999;
+}
+
+tr:hover td {
+  background-color: #330;
+}
+
+tr.action-panel td {
+  background-color: #222;
+}
+
+.action-panel textarea {
+  background: #111;
+  color: #EEE;
+  border-color: #444;
+}
+
+#dark-mode-toggle {
+  background: #FFF;
+  color: #000;
+  border-color: #CCC;
+}

--- a/public/assets/css/diff-dark.css
+++ b/public/assets/css/diff-dark.css
@@ -1,0 +1,4 @@
+body {
+  background: #999;
+}
+

--- a/public/assets/css/diff.css
+++ b/public/assets/css/diff.css
@@ -1,4 +1,5 @@
 main {
+  position: relative;
   max-width: 100%;
   margin: 0 1em 2em 1em;
 }
@@ -142,4 +143,15 @@ tr.action-panel td {
  display: block;
  width: calc(100% - 2em);
  margin: 1em 0;
+}
+
+#dark-mode-toggle {
+  position: absolute;
+  right: 5px;
+  top: 5px;
+  background-color: #000;
+  color: #FFF;
+  border: solid 1px #111;
+  font-weight: bold;
+  padding: 1em;
 }

--- a/public/assets/js/diff.js
+++ b/public/assets/js/diff.js
@@ -104,11 +104,9 @@
 
     if (typeof on === "undefined") on = !wasOn;
 
-    if (wasOn === on) return;
 
-    if (!on) {
-      $("#" + DARK_CSS_LINK_ID).remove();
-    } else {
+    $("#" + DARK_CSS_LINK_ID).remove();
+    if (on) {
       $("<link>", {
         "id": DARK_CSS_LINK_ID,
         "rel": "stylesheet",
@@ -182,11 +180,22 @@
 
   // Add a dark mode toggle button in the top right of the page
   (function () {
+    var $button;
+
     if (typeof $.cookie !== "undefined") {
       toggleDarkMode($.cookie("darkMode") === "on");
     }
 
-    // TODO: add the toggle button
+    $button = $("<button>", { "id": "dark-mode-toggle" });
+    $button.text("Light/Dark");
+
+    $button.on("click", function () { toggleDarkMode(); });
+
+    $button.appendTo($("main"));
+
+    if (typeof $.cookie === "undefined") return;
+    toggleDarkMode($.cookie("darkMode") === "on");
+
   }());
 
 }(window.jQuery));

--- a/public/assets/js/jquery.cookie.js
+++ b/public/assets/js/jquery.cookie.js
@@ -1,0 +1,117 @@
+/*!
+ * jQuery Cookie Plugin v1.4.1
+ * https://github.com/carhartl/jquery-cookie
+ *
+ * Copyright 2013 Klaus Hartl
+ * Released under the MIT license
+ */
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['jquery'], factory);
+	} else if (typeof exports === 'object') {
+		// CommonJS
+		factory(require('jquery'));
+	} else {
+		// Browser globals
+		factory(jQuery);
+	}
+}(function ($) {
+
+	var pluses = /\+/g;
+
+	function encode(s) {
+		return config.raw ? s : encodeURIComponent(s);
+	}
+
+	function decode(s) {
+		return config.raw ? s : decodeURIComponent(s);
+	}
+
+	function stringifyCookieValue(value) {
+		return encode(config.json ? JSON.stringify(value) : String(value));
+	}
+
+	function parseCookieValue(s) {
+		if (s.indexOf('"') === 0) {
+			// This is a quoted cookie as according to RFC2068, unescape...
+			s = s.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+		}
+
+		try {
+			// Replace server-side written pluses with spaces.
+			// If we can't decode the cookie, ignore it, it's unusable.
+			// If we can't parse the cookie, ignore it, it's unusable.
+			s = decodeURIComponent(s.replace(pluses, ' '));
+			return config.json ? JSON.parse(s) : s;
+		} catch(e) {}
+	}
+
+	function read(s, converter) {
+		var value = config.raw ? s : parseCookieValue(s);
+		return $.isFunction(converter) ? converter(value) : value;
+	}
+
+	var config = $.cookie = function (key, value, options) {
+
+		// Write
+
+		if (value !== undefined && !$.isFunction(value)) {
+			options = $.extend({}, config.defaults, options);
+
+			if (typeof options.expires === 'number') {
+				var days = options.expires, t = options.expires = new Date();
+				t.setTime(+t + days * 864e+5);
+			}
+
+			return (document.cookie = [
+				encode(key), '=', stringifyCookieValue(value),
+				options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
+				options.path    ? '; path=' + options.path : '',
+				options.domain  ? '; domain=' + options.domain : '',
+				options.secure  ? '; secure' : ''
+			].join(''));
+		}
+
+		// Read
+
+		var result = key ? undefined : {};
+
+		// To prevent the for loop in the first place assign an empty array
+		// in case there are no cookies at all. Also prevents odd result when
+		// calling $.cookie().
+		var cookies = document.cookie ? document.cookie.split('; ') : [];
+
+		for (var i = 0, l = cookies.length; i < l; i++) {
+			var parts = cookies[i].split('=');
+			var name = decode(parts.shift());
+			var cookie = parts.join('=');
+
+			if (key && key === name) {
+				// If second argument (value) is a function it's a converter...
+				result = read(cookie, value);
+				break;
+			}
+
+			// Prevent storing a cookie that we couldn't decode.
+			if (!key && (cookie = read(cookie)) !== undefined) {
+				result[name] = cookie;
+			}
+		}
+
+		return result;
+	};
+
+	config.defaults = {};
+
+	$.removeCookie = function (key, options) {
+		if ($.cookie(key) === undefined) {
+			return false;
+		}
+
+		// Must not alter options, thus extending a fresh object...
+		$.cookie(key, '', $.extend({}, options, { expires: -1 }));
+		return !$.cookie(key);
+	};
+
+}));


### PR DESCRIPTION
Uses diff.js to add a button to toggle a dark theme.

Closes #2.

The dark theme is applied by adding a stylesheet `link` to the DOM, which overrides colors of the page.
If jQuery.cookie is available, it is used to read and write a cookie to persist the setting.
